### PR TITLE
Updates to readme, schema and extensions.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Multiple buyers per Contract 
+# Multiple Buyers per Contract 
 
 ## Background
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,22 @@
-# Multiple Buyers Extension
+# Multiple buyers per Contract 
 
 ## Background
 
-The core OCDS schema provides space for only one single buyer to be described for each contracting process, thus making it impossible to fit more than one. 
-However, for the Mexican case, it is very common that one contract is paid by more than one buyer (institution).
-This extension provides a way to provide multiple buyers per contract.
+The core OCDS schema provides space for a single buyer to be described at the top level of each contracting process (`release.buyer`), specified using an OrganizationReference object, which cross-references an entry in the `parties` array. 
+
+Whilst more than one organization may be included in the `parties` array with the `role` of "buyer", it is not possible in core OCDS to associate particular buyers with particular contracts. 
+
+In some contexts, including Mexican public procurement, it is very common that a contract is paid for by more than one buyer (institution).
+
+This extension provides a way to reference multiple buyers (who should be present in the `parties` array) at the level of each individual contract.
 
 ## Extension fields
 
-This extension adds a buyers’ property to the contract section of OCDS.
-contract.buyers is an OrganizationReference consisting of the following fields:
+This extension adds a `buyers` property to the contract section of OCDS.
+`contract.buyers` is an array of OrganizationReference objects consisting of the following fields:
 
-    • name - The name of the party being referenced. This must match the name of an entry in the parties section.
-    • id - The id of the party being referenced. This must match the id of an entry in the parties section.
+• name - The name of the party being referenced. This must match the name of an entry in the parties section.
+• id - The id of the party being referenced. This must match the id of an entry in the parties section.
 
 ## Example
 
@@ -29,3 +33,15 @@ contract.buyers is an OrganizationReference consisting of the following fields:
     }]
   }]
 ```
+
+## Notes
+
+Applications that are not aware of this extension may assume that the organization referenced in `release.buyer` is the buyer for all contracts in the process. 
+
+If there is a lead buyer organization, this organization may referenced in `release.buyer`. In other cases, to avoid misinterpretation of the data `release.buyer` should be left blank. 
+
+This extension is similar to the [Contract Level Buyer Information](https://github.com/open-contracting/ocds_multiple_buyers_extension) which adds a `contract.buyer` (singular) property, for cases where there is a different buyer for each contract, but only ever one buyer per contract. 
+
+## Issues
+
+This extension is maintained by [transpresupuestaria](https://github.com/transpresupuestaria). 

--- a/extension.json
+++ b/extension.json
@@ -1,1 +1,11 @@
-{"name":"multiple_buyers","description":"multiple buyers for a contract"}
+{
+  "name": {
+    "en": "Multiple buyers per contract"
+  },
+  "description": {
+    "en": "Adds a buyers array to each contract, allowing one or more buyers to be specified for each individual contract within an overall contracting process."
+  },
+  "documentationUrl": {
+    "en": "https://github.com/transpresupuestaria/ocds_multiple_buyers_extension"
+  }
+}

--- a/release-schema.json
+++ b/release-schema.json
@@ -3,6 +3,8 @@
     "Contract": {
       "properties": {
         "buyers": {
+          "title":"Buyers",
+          "description":"A buyer is an entity whose budget will be used to purchase the goods, works or services covered by this contract. If each buyer signs a separate contract, they should be listed against separate contracts in the contracts array. This array can be used when multiple buyers are party to the same contract.",
           "type": "array",
           "$ref": "#/definitions/OrganizationReference"
         }

--- a/release-schema.json
+++ b/release-schema.json
@@ -2,10 +2,10 @@
   "definitions": {
     "Contract": {
       "properties": {
-        "buyers": [{
+        "buyers": {
           "type": "array",
           "$ref": "#/definitions/OrganizationReference"
-        }]
+        }
       }
     }
   }


### PR DESCRIPTION
There is an updated format for [extension.json](https://github.com/open-contracting/standard_extension_template/blob/master/README.md) which I've used here.

I've suggested some naming updates to the title to align with the suggestions [in the review here](https://github.com/open-contracting/extension_registry/pull/77/files) 

I've also updated the readme to disambiguate between this extension, and the contract level buyer extension. 