### PR TITLE
Placing OrganizationReference within items

### DIFF
--- a/release-schema.json
+++ b/release-schema.json
@@ -3,10 +3,15 @@
     "Contract": {
       "properties": {
         "buyers": {
-          "title":"Buyers",
-          "description":"A buyer is an entity whose budget will be used to purchase the goods, works or services covered by this contract. If each buyer signs a separate contract, they should be listed against separate contracts in the contracts array. This array can be used when multiple buyers are party to the same contract.",
-          "type": "array",
-          "$ref": "#/definitions/OrganizationReference"
+          "title": "Buyers",
+          "description": "A buyer is an entity whose budget will be used to purchase the goods, works or services covered by this contract. If each buyer signs a separate contract, they should be listed against separate contracts in the contracts array. This array can be used when multiple buyers are party to the same contract.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/OrganizationReference"
+          }
         }
       }
     }


### PR DESCRIPTION
This fixes the extension, so that it validates for an array of buyers, not a single buyers object.