### PR TITLE
Add "schemas" and "compatibility" to extension.json

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -7,5 +7,11 @@
   },
   "documentationUrl": {
     "en": "https://github.com/transpresupuestaria/ocds_multiple_buyers_extension"
-  }
+  },
+  "schemas": [
+    "release-schema.json"
+  ],
+  "compatibility": [
+    "1.1"
+  ]
 }


### PR DESCRIPTION
We made some small changes to the [template extension.json](https://github.com/open-contracting/standard_extension_template#extensionjson), which we've reflected in this PR.

These changes are necessary to be included in the extension registry.